### PR TITLE
Revert "ASoC: msm: fix integer overflow for long duration offload pla…

### DIFF
--- a/include/uapi/sound/compress_offload.h
+++ b/include/uapi/sound/compress_offload.h
@@ -67,7 +67,7 @@ struct snd_compr_params {
  */
 struct snd_compr_tstamp {
 	__u32 byte_offset;
-	__u64 copied_total;
+	__u32 copied_total;
 	__u32 pcm_frames;
 	__u32 pcm_io_frames;
 	__u32 sampling_rate;

--- a/sound/core/compress_offload.c
+++ b/sound/core/compress_offload.c
@@ -186,7 +186,7 @@ static int snd_compr_update_tstamp(struct snd_compr_stream *stream,
 	err = stream->ops->pointer(stream, tstamp);
 	if (err)
 		return err;
-	pr_debug("dsp consumed till %d total %llu bytes\n",
+	pr_debug("dsp consumed till %d total %d bytes\n",
 		tstamp->byte_offset, tstamp->copied_total);
 	if (stream->direction == SND_COMPRESS_PLAYBACK)
 		stream->runtime->total_bytes_transferred = tstamp->copied_total;


### PR DESCRIPTION
…yback"

This reverts commit 5396710759fcf2595e76e180940f7aa4302ac6dc.